### PR TITLE
Delete .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-config.py
-__pycache__


### PR DESCRIPTION
There is no use of this now, this was for hiding the API key, but now I am using the Heroku Environment variable to get the TOKEN.